### PR TITLE
Build: Improve ESM support, fix default export type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking** Package for better consumption from ECMAScript modules. CommonJS consumers must now
+  `require('webpack-web-app-manifest-plugin').default` to access the plugin.
+
 ### Removed
 
 - Drop support for Node.js < 12 (current LTS maintenance release).

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "collectCoverageFrom": [
       "src/**/*.ts"
     ],
+    "watchPathIgnorePatterns": [
+      "dist"
+    ],
     "testURL": "http://localhost/",
     "coverageDirectory": "./reports/coverage",
     "coverageThreshold": {

--- a/src/__tests__/plugin.tests.js
+++ b/src/__tests__/plugin.tests.js
@@ -1,9 +1,10 @@
-const WebAppManifestPlugin = require('..');
+const WebAppManifestPlugin = require('..').default;
 const { webpack } = require('webpack');
 const path = require('path');
 const fs = require('fs/promises');
 const rimraf = require('rimraf').sync;
 const glob = require('glob').sync;
+const { execSync } = require('child_process');
 
 const distPath = path.join(__dirname, '..', '..', '.test-output');
 
@@ -398,5 +399,16 @@ describe('Using asset modules', () => {
     expect(stats.toJson().assetsByChunkName['app-manifest']).toEqual([
       expect.stringMatching(/web-app-manifest\/manifest-[0-9a-f]{8}\.json/),
     ]);
+  });
+});
+
+describe('CommonJS and ESM imports are compatible', () => {
+  beforeAll(() => {
+    execSync('yarn build');
+  });
+  it('exposes the same plugin', async () => {
+    const { default: esmPlugin } = await import('webpack-web-app-manifest-plugin');
+    const { default: cjsPlugin } = require('webpack-web-app-manifest-plugin');
+    expect(esmPlugin).toBe(cjsPlugin);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export interface Config {
   /** An output path where the manifest file should be written. */
   destination: string;
   /** A function to determine if a webpack asset should be included as an icon in the web app manifest. The function accepts a `filename` parameter and returns true or false. */
-  isAssetManifestIcon: (filename: string) => boolean;
+  isAssetManifestIcon?: (filename: string) => boolean;
   /** A function to determine the icon size of any asset that passes the check `isAssetManifestIcon()`. The function accepts a `fileName` parameter and returns an object `{ width, height }`. */
   getIconSize?: (filename: string) => Dimensions;
   /** A function to determine the type of any asset that passes the check `isAssetManifestIcon()`. The function accepts a `fileName` parameter and returns a string describing the mime type of the asset, ex. "image/png". */

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ export interface Dimensions {
   height: number;
 }
 
-class WebAppManifestPlugin {
+export default class WebAppManifestPlugin {
   name: string;
   content: WebAppManifest;
   destination: string;
@@ -204,5 +204,3 @@ class WebAppManifestPlugin {
     });
   }
 }
-
-module.exports = WebAppManifestPlugin;


### PR DESCRIPTION
Improves the ESM compatibility and types of this package.

This is a **breaking change** that requires consumers to change `require('webpack-web-app-manifest-plugin')` to `require('webpack-web-app-manifest-plugin').default` to get the same behavior.

This fixes a missing type for the default export. TypeScript never saw the exported `module.exports = ` so the most interesting type in this package was never exposed;

```ts
export interface Config { /* … */ }
export interface Dimensions { /* … */ }
// missing `export default class WebAppManifestPlugin` !!!
```

With this change, the class is included in the declarations as expected:

```ts
export interface Config { /* … */ }
export interface Dimensions { /* … */ }
export default class WebAppManifestPlugin { /* … */ } // ✅ 
```

Usage of ESM type exports with `module.exports` resulted in strange behavior. The compiled output would include both an `__esModule` flag and `module.exports = …`.

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
// …
module.exports = WebAppManifestPlugin;
```

In particular, it was strange to export some names _and_ use `module.exports`.

With this change, we get something more coherent:

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
// …
exports.default = WebAppManifestPlugin;
```

We attach our "default" export to the exports object rather than replacing the exports object.